### PR TITLE
Add support for  mounting  APFS volumes

### DIFF
--- a/CONFIG.example.sh
+++ b/CONFIG.example.sh
@@ -9,3 +9,6 @@ FILE_EXT=txt
 TIMER=0
 # Set a message to display when the time's up.
 ALERT_MESSAGE=$'Time\'s up!'
+# Optionally mount an APFS drive (provide disk id).
+# Provide the volume id, e.g., disk1s1.
+APFS_MOUNT=

--- a/jnl.sh
+++ b/jnl.sh
@@ -2,6 +2,14 @@
 # @TODO RUN ME THROUGH A LINTER
 cd "$(dirname "$0")"
 . ./CONFIG.sh
+
+# Mount an APFS drive.
+if [ ! -z "$APFS_MOUNT" ] &&
+   [ ! -d "$FILES_DIR" ]
+then
+ diskutil apfs unlock "$APFS_MOUNT"
+fi
+
 if [ ! -z "$FILES_DIR" ] &&
    [ ! -z "$EDITOR_APP" ] &&
    [ ! -z "$FILE_EXT" ] &&


### PR DESCRIPTION
Allows user to specificy an APFS volume id, e.g., disk1s1,
to mount with OS X's `diskutil` command. This can be used
for storing records in an encrypted volume.